### PR TITLE
(Possibly) missing option TARGET_CPU_CORTEX_A53

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -32,6 +32,9 @@ TARGET_2ND_CPU_ABI := armeabi-v7a
 TARGET_2ND_CPU_ABI2 := armeabi
 TARGET_2ND_CPU_VARIANT := cortex-a53
 
+# Work around Cortex-A53 errata
+TARGET_CPU_CORTEX_A53  := true
+
 # Board
 TARGET_BOARD_PLATFORM := msm8953
 TARGET_BOARD_PLATFORM_GPU := qcom-adreno506


### PR DESCRIPTION
I am unsure if this is still relevant, but weren't there errata for the cortex a53 that needed to be worked around using:
TARGET_CPU_CORTEX_A53  := true
?